### PR TITLE
Make @covalent/data an optional dependency

### DIFF
--- a/mock-api/schemas/items.yaml
+++ b/mock-api/schemas/items.yaml
@@ -1,7 +1,7 @@
 # this is a sample schema file for a user object.
 
 ---
-initial_entries: 4
+initial_entries: 10
 randomize: false
 item_id: _uuid_
 name: _firstname_ _lastname_

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@covalent/markdown": "0.9.1",
     "@covalent/paging": "0.9.1",
     "@covalent/search": "0.9.1",
-    "@covalent/data": "0.4.0",
     "ts-helpers": "^1.1.1"
   },
   "devDependencies": {
@@ -77,5 +76,8 @@
     "ts-node": "1.2.1",
     "tslint": "^3.14.0",
     "typescript": "^2.0.2"
+  },
+  "optionalDependencies": {
+    "@covalent/data": "0.4.0"
   }
 }

--- a/scripts/ghpages-deploy
+++ b/scripts/ghpages-deploy
@@ -2,6 +2,15 @@
 echo 'Checking out develop branch to base deployment from it.'
 git checkout develop
 
+echo 'Replace api endpoint with heroku'
+
+cat <<'EOF' >> api.config.ts
+export const MOCK_API: string = "https://whispering-beyond-86495.herokuapp.com";
+EOF
+
+mv src/config/api.config.ts api.config.ts.default
+mv api.config.ts src/config/api.config.ts
+
 echo 'Started building process.'
 ng build -prod
 

--- a/src/app/dashboard-product/features/+form/form.component.html
+++ b/src/app/dashboard-product/features/+form/form.component.html
@@ -1,50 +1,50 @@
 <md-card tdMediaToggle="gt-xs" [mediaClasses]="['push']">
   <md-card-title>
-    <div layout="row" layout-align="start center">
-      <button md-icon-button (click)="goBack()"><md-icon>arrow_back</md-icon></button>
-      <span>Feature Form</span>
-    </div>
+    Feature Form
   </md-card-title>
   <md-divider></md-divider>
-  <md-card-content class="md-padding">
+  <md-card-content class="push-bottom-none">
     <form #featureForm="ngForm">
-      <div layout="row" layout-wrap>
-        <md-input 
-                  #titleElement
+      <div layout="row">
+        <md-input #titleElement
                   #titleControl="ngModel"
-                  flex="100" 
+                  flex 
                   type="text" 
                   placeholder="Feature Title" 
                   [(ngModel)]="title" 
                   name="title" 
                   maxlength="20" 
                   required>
-          <md-hint align="start" [hidden]="titleControl.pristine" class="tc-red-600">
-            <span [hidden]="!titleControl.errors?.required">Required</span>
+          <md-hint align="start">
+            <span [hidden]="titleControl.pristine || !titleControl.errors?.required" class="tc-red-600">Required</span>
           </md-hint>
           <md-hint align="end">{{titleElement.characterCount}} / 20</md-hint>
         </md-input>
+      </div>
+      <div layout="row" class="push-top">
         <md-input #userElement
                   #userControl="ngModel"
-                  flex="100" 
+                  flex
                   type="text" 
                   placeholder="User" 
                   [(ngModel)]="user" 
                   name="user"
                   maxlength="30"
                   required>
-          <md-hint align="start" [hidden]="userControl.pristine" class="tc-red-600">
-            <span [hidden]="!userControl.errors?.required">Required</span>
+          <md-hint align="start">
+            <span [hidden]="userControl.pristine || !userControl.errors?.required" class="tc-red-600">Required</span>
           </md-hint>
           <md-hint align="end">{{userElement.characterCount}} / 30</md-hint>
         </md-input>
-        <md-slide-toggle color="primary" [(ngModel)]="enabled" name="enabled">Enabled</md-slide-toggle>
+      </div>
+      <div layout="row">
+        <md-slide-toggle [(ngModel)]="enabled" name="enabled">Enabled</md-slide-toggle>
       </div>
     </form>
     </md-card-content>
     <md-divider></md-divider>
     <md-card-actions>
-      <button md-button [disabled]="!featureForm.valid" class="md-primary" (click)="save()">SAVE</button>
-      <button md-button class="md-accent" (click)="goBack()">CANCEL</button>
+      <button md-button [disabled]="!featureForm.valid" color="primary" (click)="save()">SAVE</button>
+      <button md-button (click)="goBack()">CANCEL</button>
     </md-card-actions>
   </md-card>

--- a/src/app/dashboard-product/overview/overview.component.html
+++ b/src/app/dashboard-product/overview/overview.component.html
@@ -26,7 +26,7 @@
                         fillOpacity="0.95">
                     <td-axis-x [link]="chartBar1" [ticks]="true" [show]="true" [grid]="false"></td-axis-x>
                     <td-axis-y-right [link]="chartBar1" [show]="true" [grid]="true"></td-axis-y-right>
-                    <td-chart-bar #chartBar1 [colors]="['lightBlue', 'deepOrange']"
+                    <td-chart-bar #chartBar1 [colors]="['blue', 'deepOrange']"
                         [data]="jsonData"
                         [padding]="0.25"
                         bottomAxis="x"

--- a/src/app/dashboard-product/overview/overview.component.ts
+++ b/src/app/dashboard-product/overview/overview.component.ts
@@ -19,7 +19,6 @@ export class ProductOverviewComponent implements AfterViewInit {
   jsonData: any = [
     {'x': 'Ingest', 'y': 69},
     {'x': 'Monitoring', 'y': 47},
-    {'x': 'Deployment', 'y': 48},
     {'x': 'Containers', 'y': 63},
     {'x': 'Compute', 'y': 82},
     {'x': 'Data Lake', 'y': 52},

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -17,7 +17,7 @@
                 <td-charts [margin]="{top: 60, bottom: 50}"
                           chartHeight="325"
                           [shadow]="true">
-                  <td-axis-x [link]="chartLine1" [ticks]="true" [show]="true" [grid]="false" legend="Year"></td-axis-x>
+                  <td-axis-x [link]="chartLine1" [ticks]="true" [show]="true" [grid]="false" legend=""></td-axis-x>
                   <td-axis-y-left [link]="chartLine1" [ticks]="true" [show]="true" [grid]="true" legend="Sales($)"></td-axis-y-left>
                   <td-chart-line #chartLine1
                           dataSrc="data/datatime.csv"
@@ -35,8 +35,9 @@
               <md-tab>
                 <template md-tab-label>1 MONTH</template>
                 <td-charts [margin]="{top: 60, bottom: 50}"
-                          chartHeight="325">
-                  <td-axis-x [link]="chartLine2" [ticks]="true" [show]="true" [grid]="false" legend="Year"></td-axis-x>
+                          chartHeight="325"
+                          [shadow]="true">
+                  <td-axis-x [link]="chartLine2" [ticks]="true" [show]="true" [grid]="false" legend=""></td-axis-x>
                   <td-axis-y-left [link]="chartLine2" [ticks]="true" [show]="true" [grid]="true" legend="Sales($)"></td-axis-y-left>
                   <td-chart-line #chartLine2 
                           dataSrc="data/datatime.csv"
@@ -55,8 +56,9 @@
                 <template md-tab-label>1 YEAR</template>
                 <td-charts
                           [margin]="{top: 60, bottom: 50}"
-                          chartHeight="325">
-                  <td-axis-x [link]="chartLine3" [ticks]="true" [show]="true" [grid]="false" legend="Year"></td-axis-x>
+                          chartHeight="325"
+                          [shadow]="true">
+                  <td-axis-x [link]="chartLine3" [ticks]="true" [show]="true" [grid]="false" legend=""></td-axis-x>
                   <td-axis-y-left [link]="chartLine3" [ticks]="true" [show]="true" [grid]="true" legend="Sales($)"></td-axis-y-left>
                   <td-chart-line #chartLine3 
                           dataSrc="data/datatime.csv"

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -9,3 +9,9 @@
 .icon {
   font-size: 48px;
 }
+// Chart font size
+:host /deep/ {
+    .tick text {
+        font-size: 14px;
+    }
+}

--- a/src/app/logs/logs.component.html
+++ b/src/app/logs/logs.component.html
@@ -13,25 +13,23 @@
       <span>All Product Logs</span>
       <span flex></span>
     </div>
-    <div class="md-padding">
-      <md-card>
-        <td-search-box class="md-padding" placeholder="search" [alwaysVisible]="true"></td-search-box>
-        <md-divider></md-divider>
-        <template tdLoading="items.load">
-          <md-list class="will-load" >
-            <div class="md-padding" *ngIf="!items || items.length === 0" layout="row" layout-align="center center">
-              <h3>No logs to display.</h3>
-            </div>
-            <template let-item let-last="last" ngFor [ngForOf]="items">
-              <md-list-item [title]="item.description">
-                <md-icon md-list-icon> {{item.icon}} </md-icon>
-                <h3 md-line> {{item.description}} <span class="md-caption tc-grey-600">({{item.created}})</span> </h3>
-                <p md-line > {{item.name}} </p>
-              </md-list-item>
-              <md-divider *ngIf="!last"></md-divider>
-            </template>
-          </md-list>
-        </template>
-      </md-card>
-    </div>
+    <md-card tdMediaToggle="gt-xs" [mediaClasses]="['push']">
+      <md-card-title>Logs</md-card-title>
+      <md-divider></md-divider>
+      <template tdLoading="items.load">
+        <md-list class="will-load" >
+          <div class="md-padding" *ngIf="!items || items.length === 0" layout="row" layout-align="center center">
+            <h3>No logs to display.</h3>
+          </div>
+          <template let-item let-last="last" ngFor [ngForOf]="items">
+            <md-list-item [title]="item.description">
+              <md-icon md-list-icon> {{item.icon}} </md-icon>
+              <h3 md-line> {{item.description}} <span class="md-caption tc-grey-600">({{item.created}})</span> </h3>
+              <p md-line > {{item.name}} </p>
+            </md-list-item>
+            <md-divider *ngIf="!last"></md-divider>
+          </template>
+        </md-list>
+      </template>
+    </md-card>
   </td-layout-nav-list>

--- a/src/app/users/+form/form.component.html
+++ b/src/app/users/+form/form.component.html
@@ -6,6 +6,9 @@
     <a md-icon-button buttonDisableFix md-tooltip="Github" href="https://github.com/teradata/covalent" target="_blank"><md-icon svgSrc="assets/icons/github.svg"></md-icon></a>
   </div>
   <td-layout-manage-list #list>
+    <md-toolbar list-items>
+      <span>Users</span>
+    </md-toolbar>
     <md-nav-list list-items>
       <a md-list-item>
         <md-icon md-list-icon>account_circle</md-icon>
@@ -29,48 +32,56 @@
       </a>
     </md-nav-list>
     <div toolbar-buttons layout="row" layout-align="start center" flex>
-      <span>{{action}} user</span>
-      <span flex></span>
-      <button md-button class="md-icon-button"><md-icon class="md-24">view_module</md-icon></button>
-      <button md-button class="md-icon-button"><md-icon class="md-24">sort</md-icon></button>
-      <button md-button class="md-icon-button"><md-icon class="md-24">settings</md-icon></button>
-      <button md-button class="md-icon-button"><md-icon class="md-24">more_vert</md-icon></button>
+      <span class="text-capital">{{action}} user</span>
     </div>
-    <md-card>
-    <md-card-content class="md-padding">
-      <form #userForm="ngForm">
-        <div layout="row" layout-wrap>
-          <md-input #displayNameElement
-                    flex="100" 
-                    type="text" 
-                    placeholder="Display Name" 
-                    [(ngModel)]="display_name" 
-                    name="display_name" 
-                    maxlength="20" 
-                    required>
-            <md-hint align="end">{{displayNameElement.characterCount}} / 20</md-hint>
-          </md-input>
-          <md-input #emailElement
-                    #emailControl="ngModel"
-                    flex="100" 
-                    type="text" 
-                    placeholder="Email" 
-                    [(ngModel)]="email" 
-                    name="email"
-                    maxlength="30"
-                    pattern="\S*@\S+"
-                    required>
-            <md-hint align="start" [hidden]="emailControl.pristine || !emailControl.errors?.pattern" class="tc-red-600">Pattern for e-mail is not matched.</md-hint>
-            <md-hint align="end">{{emailElement.characterCount}} / 30</md-hint>
-          </md-input>
-          <md-slide-toggle color="primary" [(ngModel)]="admin" name="admin">Admin</md-slide-toggle>
-        </div>
-      </form>
-    </md-card-content>
-    <md-card-actions>
-      <button md-button [disabled]="!userForm.valid" class="md-primary" (click)="save()">SAVE</button>
-      <button md-button class="md-accent" (click)="goBack()">CANCEL</button>
-    </md-card-actions>
+    <md-card tdMediaToggle="gt-xs" [mediaClasses]="['push']">
+      <md-card-title>User Form</md-card-title>
+      <md-divider></md-divider>
+      <md-card-content class="push-bottom-none">
+        <form #userForm="ngForm">
+          <div layout="row">
+            <md-input #displayNameElement
+                      #displayNameControl="ngModel"
+                      flex
+                      type="text" 
+                      placeholder="Display Name" 
+                      [(ngModel)]="display_name" 
+                      name="display_name" 
+                      maxlength="20" 
+                      required>
+              <md-hint align="start">
+                <span [hidden]="!displayNameControl.errors?.required" class="tc-red-600">Display Name is required!</span>
+              </md-hint>
+              <md-hint align="end">{{displayNameElement.characterCount}} / 20</md-hint>
+            </md-input>
+          </div>
+          <div layout="row" class="push-top">
+            <md-input #emailElement
+                      #emailControl="ngModel"
+                      flex 
+                      type="text" 
+                      placeholder="Email" 
+                      [(ngModel)]="email" 
+                      name="email"
+                      maxlength="30"
+                      pattern="^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$"
+                      required>
+              <md-hint align="start">
+                <span [hidden]="emailControl.pristine || !emailControl.errors?.pattern" class="tc-red-600">That's not an email!</span>
+              </md-hint>
+              <md-hint align="end">{{emailElement.characterCount}} / 30</md-hint>
+            </md-input>
+          </div>
+          <div layout="row">
+            <md-slide-toggle [(ngModel)]="admin" name="admin">Admin</md-slide-toggle>
+          </div>
+        </form>
+      </md-card-content>
+      <md-divider></md-divider>
+      <md-card-actions>
+        <button md-button [disabled]="!userForm.form.valid" color="primary" (click)="save()">SAVE</button>
+        <button md-button (click)="goBack()">CANCEL</button>
+      </md-card-actions>
     </md-card>
   </td-layout-manage-list>
 </td-layout-nav>

--- a/src/config/api.config.ts
+++ b/src/config/api.config.ts
@@ -1,0 +1,1 @@
+export const MOCK_API: string = 'http://localhost:8080';

--- a/src/services/features.service.ts
+++ b/src/services/features.service.ts
@@ -3,6 +3,7 @@ import { Response } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 
 import { HttpInterceptorService, RESTService } from '@covalent/http';
+import { MOCK_API } from '../config/api.config';
 
 export interface IFeature {
   title: string;
@@ -19,7 +20,7 @@ export class FeaturesService extends RESTService<IFeature> {
 
   constructor(private _http: HttpInterceptorService) {
     super(_http, {
-      baseUrl: 'http://localhost:8080',
+      baseUrl: MOCK_API,
       path: '/features',
     });
   }

--- a/src/services/features.service.ts
+++ b/src/services/features.service.ts
@@ -26,7 +26,7 @@ export class FeaturesService extends RESTService<IFeature> {
   }
 
   staticQuery(): Observable<IFeature[]> {
-    return this._http.get('https://whispering-beyond-86495.herokuapp.com/features')
+    return this._http.get('data/features.json')
     .map((res: Response) => {
       return res.json();
     });

--- a/src/services/features.service.ts
+++ b/src/services/features.service.ts
@@ -25,7 +25,7 @@ export class FeaturesService extends RESTService<IFeature> {
   }
 
   staticQuery(): Observable<IFeature[]> {
-    return this._http.get('data/features.json')
+    return this._http.get('https://whispering-beyond-86495.herokuapp.com/features')
     .map((res: Response) => {
       return res.json();
     });

--- a/src/services/items.service.ts
+++ b/src/services/items.service.ts
@@ -1,45 +1,27 @@
 import { Injectable } from '@angular/core';
 import { Response } from '@angular/http';
-import { HttpInterceptorService } from '@covalent/http';
+import { HttpInterceptorService, RESTService } from '@covalent/http';
 import { MOCK_API } from '../config/api.config';
 
 @Injectable()
-export class ItemsService {
+export class ItemsService extends RESTService<any> {
 
-  private staticData: string = 'data/items.json';
-  private mockApiData: string = MOCK_API;
-
-  constructor(private _http: HttpInterceptorService) {}
+  constructor(private _http: HttpInterceptorService) {
+    super(_http, {
+      baseUrl: MOCK_API,
+      path: '/items',
+    }); 
+  }
 
   staticQuery(): any {
-    return this._http.get(this.staticData)
+    return this._http.get('data/items.json')
     .map((res: Response) => {
       return res.json();
-    });
+    }); 
   }
 
   staticGet(id: string): any {
-    return this._http.get(this.staticData)
-    .map((res: Response) => {
-      let item: any;
-      res.json().forEach((s: any) => {
-        if (s.item_id === id) {
-          item = s;
-        }
-      });
-      return item;
-    });
-  }
-
-  query(): any {
-    return this._http.get(this.mockApiData)
-    .map((res: Response) => {
-      return res.json();
-    });
-  }
-
-  get(id: string): any {
-    return this._http.get(this.mockApiData)
+    return this._http.get('data/items.json')
     .map((res: Response) => {
       let item: any;
       res.json().forEach((s: any) => {

--- a/src/services/items.service.ts
+++ b/src/services/items.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { Response } from '@angular/http';
 import { HttpInterceptorService } from '@covalent/http';
+import { MOCK_API } from '../config/api.config';
 
 @Injectable()
 export class ItemsService {
 
-  private staticData: string = 'https://whispering-beyond-86495.herokuapp.com/items';
-  private mockApiData: string = 'http://localhost:8080/items';
+  private staticData: string = 'data/items.json';
+  private mockApiData: string = MOCK_API;
 
   constructor(private _http: HttpInterceptorService) {}
 

--- a/src/services/items.service.ts
+++ b/src/services/items.service.ts
@@ -5,7 +5,7 @@ import { HttpInterceptorService } from '@covalent/http';
 @Injectable()
 export class ItemsService {
 
-  private staticData: string = 'data/items.json';
+  private staticData: string = 'https://whispering-beyond-86495.herokuapp.com/items';
   private mockApiData: string = 'http://localhost:8080/items';
 
   constructor(private _http: HttpInterceptorService) {}

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -3,6 +3,7 @@ import { Response } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 
 import { HttpInterceptorService, RESTService } from '@covalent/http';
+import { MOCK_API } from '../config/api.config';
 
 export interface IUser {
   display_name: string;
@@ -18,13 +19,13 @@ export class UsersService extends RESTService<IUser> {
 
   constructor(private _http: HttpInterceptorService) {
     super(_http, {
-      baseUrl: 'http://localhost:8080',
+      baseUrl: MOCK_API,
       path: '/users',
     });
   }
 
   staticQuery(): Observable<IUser[]> {
-    return this._http.get('https://whispering-beyond-86495.herokuapp.com/users')
+    return this._http.get('data/users.json')
     .map((res: Response) => {
       return res.json();
     });

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -24,7 +24,7 @@ export class UsersService extends RESTService<IUser> {
   }
 
   staticQuery(): Observable<IUser[]> {
-    return this._http.get('data/users.json')
+    return this._http.get('https://whispering-beyond-86495.herokuapp.com/users')
     .map((res: Response) => {
       return res.json();
     });

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -27,6 +27,11 @@ a[md-icon-button] {
     flex-grow: 1;
 }
 
+// Capitalize
+.text-capital {
+  text-transform: capitalize;
+}
+
 // Manage List layout overflow is too short
 td-layout-manage-list .md-sidenav-content > .md-content > .md-content {
     padding-bottom: 140px;


### PR DESCRIPTION
## Description

- Due to @covalent/data only supporting 64-bit architectures, it has now become an optional dependency.
- Quickstart static data has been replaced with live @covalent/data examples, hosted on heroku.

#### Test Steps

- [x] `rm node_modules; npm i`
- [x] `ng serve`
- [x] go to [locahost:4200](http://localhost:4200) and check that data tabes and users still appear.