### PR TITLE
They rebranded the CLI, it's no more angular-cli, now it's @angular/cli.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Quickstart App with @covalent packages
 ## Setup
 
 * Ensure you have Node 4.4+ and NPM 3+ installed.
-* Install Angular CLI `npm i -g angular-cli@latest`
+* Install Angular CLI `npm i -g @angular/cli@latest`
 * Install Typescript 2.0 `npm i -g typescript`
 * Install TSLint `npm install -g tslint`
 * Install Protractor for e2e testing `npm install -g protractor`


### PR DESCRIPTION
Just updated the README.md to command for new version of Angular CLI because they rebranded the CLI, it's no more angular-cli, now it's @angular/cli.
